### PR TITLE
Add root Procfile and requirements

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+python bot_railway_ready/main.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+aiogram==2.25.1
+aiohttp==3.8.6


### PR DESCRIPTION
## Summary
- add root-level `Procfile` so Railway or Heroku can find the entrypoint
- copy `requirements.txt` to repo root for ease of deployment

## Testing
- `python main.py` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_684d7f89b0ec8324a51f6e2751398abb